### PR TITLE
Add Umami event tracking to key UI interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,22 @@ Follow the Shadcn pattern:
 - Mobile navigation uses `dynamic(() => import(), { ssr: false })`.
 - The projects section supports two display modes: BENTO (grid) and TREE (list).
 
+## Analytics — Umami Event Tracking
+
+The Umami script is loaded in `src/app/layout.tsx`. Track user interactions by adding the `data-umami-event` HTML attribute (no JS required).
+
+**Naming convention:** `click-{context}-{label}` (all lowercase, hyphen-separated).
+
+| Element | File | Event Name |
+|---------|------|------------|
+| Glass card "GET IN TOUCH" button | `src/components/home/HeroSection.tsx` | `click-get-in-touch-desktop` |
+| Mobile "GET IN TOUCH" button | `src/components/home/HeroButton.tsx` | `click-get-in-touch-mobile` |
+| "See more projects" link | `src/components/projects/ProjectsSection.tsx` | `click-see-more-projects` |
+| Desktop nav links (brand + #projects) | `src/components/layout/Nav.tsx` | `click-nav-{label}` |
+| Mobile nav TreeView links | `src/components/treeView.tsx` | `click-nav-mobile-{label}` |
+
+**Docs:** https://umami.is/docs/track-events
+
 ## Known Incomplete Features
 
 These are intentionally unfinished — don't "fix" them unless explicitly asked:

--- a/src/components/home/HeroButton.tsx
+++ b/src/components/home/HeroButton.tsx
@@ -11,7 +11,7 @@ export default function HeroButton() {
     };
 
     return (
-        <button className="hero-section__button" ref={glitch.ref} onClick={handleClick}>
+        <button className="hero-section__button" ref={glitch.ref} onClick={handleClick} data-umami-event="click-get-in-touch-mobile">
             GET IN TOUCH
         </button>
     );

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -120,6 +120,7 @@ export default function HeroSection() {
               <button
                 className="hero-section__glass-cta"
                 onClick={handleContact}
+                data-umami-event="click-get-in-touch-desktop"
               >
                 GET IN TOUCH
               </button>

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -31,7 +31,7 @@ const Navbar = () => {
     return (
         <nav className="container navbar" aria-label="Main Navigation">
             <div className="navbar__brand">
-                <Link href="/" className="navbar__brand-name">juanpredev</Link>
+                <Link href="/" className="navbar__brand-name" data-umami-event="click-nav-brand">juanpredev</Link>
                 <button 
                     className="navbar__toggle" 
                     onClick={toggleMenu}
@@ -48,6 +48,7 @@ const Navbar = () => {
                         href={link.href}
                         className={`navbar__links-link ${pathname === link.href ? "navbar__links-link--active" : ""}`}
                         aria-current={pathname === link.href ? "page" : undefined}
+                        data-umami-event={`click-nav-${link.label.replace('#', '')}`}
                     >
                         {link.label}
                     </Link>

--- a/src/components/projects/ProjectsSection.tsx
+++ b/src/components/projects/ProjectsSection.tsx
@@ -133,7 +133,7 @@ export default function DevToolsGrid({ featuredOnly = false, showFilters = true 
         {/* See more button */}
         {featuredOnly && (
           <div className="dev-tools-grid__see-more">
-            <Link href="/projects" className="dev-tools-grid__see-more-btn">
+            <Link href="/projects" className="dev-tools-grid__see-more-btn" data-umami-event="click-see-more-projects">
               See more projects <ArrowUpRight className="w-5 h-5 inline-block ml-1" />
             </Link>
           </div>

--- a/src/components/treeView.tsx
+++ b/src/components/treeView.tsx
@@ -28,6 +28,7 @@ const TreeItem = ({ item, isLast = false }: { item: TreeItem; isLast?: boolean }
                     <Link
                         href={item.href}
                         className="hover:text-lawn-green transition-colors duration-200 font-mono text-french-gray text-xl"
+                        data-umami-event={`click-nav-mobile-${item.label.replace('.ts', '').toLowerCase()}`}
                     >
                         {item.label}
                     </Link>


### PR DESCRIPTION
## Summary
- Add `data-umami-event` attributes to key interactive elements for tracking user engagement via Umami analytics
- No JavaScript required — uses the HTML attribute approach per [Umami docs](https://umami.is/docs/track-events)
- Document event tracking conventions in AGENTS.md

### Events added

| Element | Event Name |
|---------|------------|
| Glass card "GET IN TOUCH" button (desktop) | `click-get-in-touch-desktop` |
| Mobile "GET IN TOUCH" button | `click-get-in-touch-mobile` |
| "See more projects" link | `click-see-more-projects` |
| Desktop nav brand link | `click-nav-brand` |
| Desktop nav links | `click-nav-{label}` |
| Mobile TreeView nav links | `click-nav-mobile-{label}` |

## Test plan
- [ ] Verify each button/link renders the correct `data-umami-event` attribute in the DOM
- [ ] Confirm events appear in the Umami dashboard after deployment

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)