### PR TITLE
Proxy Umami script to bypass ad blockers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,15 +1,25 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
 import { config } from 'dotenv';
 
 config();
 
+/** @type {import('next').NextConfig} */
 export default {
   env: {
     SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID,
     SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET,
     SPOTIFY_REFRESH_TOKEN: process.env.SPOTIFY_REFRESH_TOKEN,
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/u/script.js',
+        destination: 'https://cloud.umami.is/script.js',
+      },
+      {
+        source: '/api/send',
+        destination: 'https://cloud.umami.is/api/send',
+      },
+    ];
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <Script defer src="https://cloud.umami.is/script.js" data-website-id="7db19975-013f-4646-8b49-dc5c0b9a2d87" />
+      <Script src="/u/script.js" data-website-id="7db19975-013f-4646-8b49-dc5c0b9a2d87" strategy="afterInteractive" />
       <body className={`${fira_mono.className} antialiased flex flex-col justify-between absolute inset-0 overflow-auto bg-gradient-to-br from-[#050505] via-[#0a0a0a] to-[#151515`}>
         <div className="absolute top-0 left-0 w-1/2 h-1/2 bg-gradient-to-br from-[#7af42a]/20 to-transparent blur-3xl pointer-events-none"></div>
         <div className="absolute bottom-0 right-0 w-1/2 h-1/2 bg-gradient-to-tl from-[#2ae8c4]/20 to-transparent blur-3xl pointer-events-none"></div>


### PR DESCRIPTION
## Summary
- Proxy Umami script and API calls through Next.js rewrites so ad blockers don't block analytics
- `/u/script.js` → `cloud.umami.is/script.js`
- `/api/send` → `cloud.umami.is/api/send`
- Update `<Script>` src in layout to use the proxied path

## Test plan
- [ ] Verify pageviews appear in Umami dashboard with an ad blocker enabled
- [ ] Verify `data-umami-event` clicks register in Umami Events tab

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)